### PR TITLE
nvim: vim-fern で LSP workspace file operation 通知を統合

### DIFF
--- a/nvim/dpp/plugins.toml
+++ b/nvim/dpp/plugins.toml
@@ -500,6 +500,10 @@ vim.g["fern#disable_auto_buffer_delete"] = true
 vim.g["fern#disable_auto_buffer_rename"] = true
 vim.keymap.set("n", "<C-n>", "<Cmd>Fern . -reveal=%:p -drawer -toggle<CR>")
 """
+lua_source = """
+-- fern-replacer バッファへのフックを登録する (rename 時の LSP 通知)
+require("xecua.fern_lsp").setup()
+"""
 [plugins.ftplugin]
 lua_fern = """
 vim.opt_local.list = false

--- a/nvim/dpp/plugins.toml
+++ b/nvim/dpp/plugins.toml
@@ -345,26 +345,6 @@ repo = 'MunifTanjim/nui.nvim'
 [[plugins]]
 repo = 'neovim/nvim-lspconfig'
 
-[[plugins]]
-# fork. back to original when https://github.com/antosha417/nvim-lsp-file-operations/pull/34 is merged
-repo = 'igorlfs/nvim-lsp-file-operations'
-depends = ['nvim-lspconfig']
-lua_post_source = """
-require("lsp-file-operations").setup()
-local lspconfig = require("lspconfig")
-local file_op_capabilities = vim.tbl_deep_extend(
-    "force",
-    vim.lsp.protocol.make_client_capabilities(),
-    require("lsp-file-operations").default_capabilities()
-)
-lspconfig.util.default_config = vim.tbl_extend("force", lspconfig.util.default_config, {
-    capabilities = file_op_capabilities,
-})
--- vim.lsp.enable() で起動するサーバにも同じ capability を渡す
-vim.lsp.config("*", { capabilities = file_op_capabilities })
-
-"""
-
 ## breadcrumbs
 [[plugins]]
 repo = 'SmiteshP/nvim-navic'

--- a/nvim/dpp/plugins.toml
+++ b/nvim/dpp/plugins.toml
@@ -352,13 +352,16 @@ depends = ['nvim-lspconfig']
 lua_post_source = """
 require("lsp-file-operations").setup()
 local lspconfig = require("lspconfig")
+local file_op_capabilities = vim.tbl_deep_extend(
+    "force",
+    vim.lsp.protocol.make_client_capabilities(),
+    require("lsp-file-operations").default_capabilities()
+)
 lspconfig.util.default_config = vim.tbl_extend("force", lspconfig.util.default_config, {
-    capabilities = vim.tbl_deep_extend(
-        "force",
-        vim.lsp.protocol.make_client_capabilities(),
-        require("lsp-file-operations").default_capabilities()
-    ),
+    capabilities = file_op_capabilities,
 })
+-- vim.lsp.enable() で起動するサーバにも同じ capability を渡す
+vim.lsp.config("*", { capabilities = file_op_capabilities })
 
 """
 
@@ -534,6 +537,9 @@ end, { buffer = true, expr = true }) -- 選択は<LeftMouse>でやってる
 vim.keymap.set("n", "e", "<Plug>(fern-action-open:select)", { buffer = true })
 vim.keymap.set("n", "s", "<Plug>(fern-action-open:split)", { nowait = true, buffer = true })
 vim.keymap.set("n", "v", "<Plug>(fern-action-open:vsplit)", { buffer = true })
+
+-- LSP workspace file operation 統合 (rename/new file/new dir/delete)
+require("xecua.fern_lsp").setup_keymaps()
 """
 
 [[plugins]]

--- a/nvim/lua/xecua/fern_lsp.lua
+++ b/nvim/lua/xecua/fern_lsp.lua
@@ -1,0 +1,279 @@
+--- vim-fern と LSP の workspace file operation を統合するモジュール
+--- fern の ftplugin から M.setup_keymaps() を呼び出して使う
+
+local M = {}
+
+--- workspace file operation の capability を持つ LSP クライアントを返す
+---@param capability string "willRename"|"didRename"|"willCreate"|"didCreate"|"willDelete"|"didDelete"
+---@return vim.lsp.Client[]
+local function get_capable_clients(capability)
+    return vim.tbl_filter(function(client)
+        local ops = vim.tbl_get(client.server_capabilities, "workspace", "fileOperations")
+        return ops ~= nil and ops[capability] ~= nil
+    end, vim.lsp.get_clients())
+end
+
+--- workspace edit をバッファに適用する
+---@param edit lsp.WorkspaceEdit
+---@param offset_encoding string
+local function apply_workspace_edit(edit, offset_encoding)
+    vim.lsp.util.apply_workspace_edit(edit, offset_encoding or "utf-8")
+end
+
+--- workspace/willRenameFiles を送信し、返された workspace edit を適用する
+---@param old_path string 変更前のファイルパス (絶対パス)
+---@param new_path string 変更後のファイルパス (絶対パス)
+function M.will_rename_files(old_path, new_path)
+    local params = {
+        files = { { oldUri = vim.uri_from_fname(old_path), newUri = vim.uri_from_fname(new_path) } },
+    }
+    for _, client in ipairs(get_capable_clients("willRename")) do
+        local result = client:request_sync("workspace/willRenameFiles", params, 1500)
+        if result and not result.err and result.result then
+            apply_workspace_edit(result.result, client.offset_encoding)
+        end
+    end
+end
+
+--- workspace/didRenameFiles を送信する
+---@param old_path string 変更前のファイルパス (絶対パス)
+---@param new_path string 変更後のファイルパス (絶対パス)
+function M.did_rename_files(old_path, new_path)
+    local params = {
+        files = { { oldUri = vim.uri_from_fname(old_path), newUri = vim.uri_from_fname(new_path) } },
+    }
+    for _, client in ipairs(get_capable_clients("didRename")) do
+        client:notify("workspace/didRenameFiles", params)
+    end
+end
+
+--- workspace/willCreateFiles を送信し、返された workspace edit を適用する
+---@param paths string[] 作成するファイルのパスのリスト (絶対パス)
+function M.will_create_files(paths)
+    local params = {
+        files = vim.tbl_map(function(p)
+            return { uri = vim.uri_from_fname(p) }
+        end, paths),
+    }
+    for _, client in ipairs(get_capable_clients("willCreate")) do
+        local result = client:request_sync("workspace/willCreateFiles", params, 1500)
+        if result and not result.err and result.result then
+            apply_workspace_edit(result.result, client.offset_encoding)
+        end
+    end
+end
+
+--- workspace/didCreateFiles を送信する
+---@param paths string[] 作成されたファイルのパスのリスト (絶対パス)
+function M.did_create_files(paths)
+    local params = {
+        files = vim.tbl_map(function(p)
+            return { uri = vim.uri_from_fname(p) }
+        end, paths),
+    }
+    for _, client in ipairs(get_capable_clients("didCreate")) do
+        client:notify("workspace/didCreateFiles", params)
+    end
+end
+
+--- workspace/willDeleteFiles を送信し、返された workspace edit を適用する
+---@param paths string[] 削除するファイルのパスのリスト (絶対パス)
+function M.will_delete_files(paths)
+    local params = {
+        files = vim.tbl_map(function(p)
+            return { uri = vim.uri_from_fname(p) }
+        end, paths),
+    }
+    for _, client in ipairs(get_capable_clients("willDelete")) do
+        local result = client:request_sync("workspace/willDeleteFiles", params, 1500)
+        if result and not result.err and result.result then
+            apply_workspace_edit(result.result, client.offset_encoding)
+        end
+    end
+end
+
+--- workspace/didDeleteFiles を送信する
+---@param paths string[] 削除されたファイルのパスのリスト (絶対パス)
+function M.did_delete_files(paths)
+    local params = {
+        files = vim.tbl_map(function(p)
+            return { uri = vim.uri_from_fname(p) }
+        end, paths),
+    }
+    for _, client in ipairs(get_capable_clients("didDelete")) do
+        client:notify("workspace/didDeleteFiles", params)
+    end
+end
+
+--- fern の cursor node の絶対パスを返す
+---@return string|nil
+local function fern_cursor_path()
+    local ok, path = pcall(vim.api.nvim_eval, "fern#helper#new().sync.get_cursor_node()._path")
+    return (ok and type(path) == "string" and #path > 0) and path or nil
+end
+
+--- fern で選択 (またはマーク) されているノードの絶対パスのリストを返す
+--- マークされたノードがなければ cursor node のパスを返す
+---@return string[]|nil
+local function fern_selected_paths()
+    local ok, paths = pcall(
+        vim.api.nvim_eval,
+        "map(fern#helper#new().sync.get_selected_nodes(), {_, n -> n._path})"
+    )
+    return (ok and type(paths) == "table" and #paths > 0) and paths or nil
+end
+
+--- fern のツリーを再読み込みする
+local function fern_reload()
+    pcall(vim.fn["fern#action#call"], "reload:all")
+end
+
+--- vim-fern バッファ用の LSP file operation キーマップを設定する
+--- fern の ftplugin から呼び出すこと
+function M.setup_keymaps()
+    -- ファイル/ディレクトリのリネーム (r)
+    -- workspace/willRenameFiles でインポートパス等を事前更新し、
+    -- リネーム後に workspace/didRenameFiles で LSP 内部状態を同期する
+    vim.keymap.set("n", "r", function()
+        local old_path = fern_cursor_path()
+        if not old_path then
+            return
+        end
+
+        local old_name = vim.fn.fnamemodify(old_path, ":t")
+        vim.cmd("redraw")
+        local new_name = vim.fn.input("New name: ", old_name)
+        if new_name == "" or new_name == old_name then
+            return
+        end
+
+        local new_path = vim.fn.fnamemodify(old_path, ":h") .. "/" .. new_name
+
+        -- リネーム前に LSP へ通知して workspace edit (インポートパス変更等) を適用する
+        M.will_rename_files(old_path, new_path)
+
+        -- 実際にリネームする
+        if vim.fn.rename(old_path, new_path) ~= 0 then
+            vim.notify("[fern-lsp] Rename failed: " .. old_path, vim.log.levels.ERROR)
+            return
+        end
+
+        -- 対応するバッファが開いていればパスを更新する
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+            if vim.api.nvim_buf_is_loaded(bufnr) and vim.api.nvim_buf_get_name(bufnr) == old_path then
+                vim.api.nvim_buf_set_name(bufnr, new_path)
+                vim.api.nvim_buf_call(bufnr, function()
+                    vim.cmd("edit")
+                end)
+            end
+        end
+
+        -- リネーム後に LSP へ通知する
+        M.did_rename_files(old_path, new_path)
+
+        fern_reload()
+    end, { buffer = true, desc = "Fern: rename with LSP notification" })
+
+    -- 新規ファイル作成 (n)
+    vim.keymap.set("n", "n", function()
+        local cursor_path = fern_cursor_path()
+        if not cursor_path then
+            return
+        end
+
+        local dir = vim.fn.isdirectory(cursor_path) == 1 and cursor_path
+            or vim.fn.fnamemodify(cursor_path, ":h")
+
+        vim.cmd("redraw")
+        local name = vim.fn.input("New file: ")
+        if name == "" then
+            return
+        end
+
+        local new_path = dir .. "/" .. name
+
+        M.will_create_files({ new_path })
+
+        if vim.fn.writefile({}, new_path) ~= 0 then
+            vim.notify("[fern-lsp] Failed to create file: " .. new_path, vim.log.levels.ERROR)
+            return
+        end
+
+        M.did_create_files({ new_path })
+        fern_reload()
+    end, { buffer = true, desc = "Fern: new file with LSP notification" })
+
+    -- 新規ディレクトリ作成 (N)
+    vim.keymap.set("n", "N", function()
+        local cursor_path = fern_cursor_path()
+        if not cursor_path then
+            return
+        end
+
+        local dir = vim.fn.isdirectory(cursor_path) == 1 and cursor_path
+            or vim.fn.fnamemodify(cursor_path, ":h")
+
+        vim.cmd("redraw")
+        local name = vim.fn.input("New dir: ")
+        if name == "" then
+            return
+        end
+
+        local new_path = dir .. "/" .. name
+
+        M.will_create_files({ new_path })
+
+        if vim.fn.mkdir(new_path, "p") ~= 1 then
+            vim.notify("[fern-lsp] Failed to create directory: " .. new_path, vim.log.levels.ERROR)
+            return
+        end
+
+        M.did_create_files({ new_path })
+        fern_reload()
+    end, { buffer = true, desc = "Fern: new directory with LSP notification" })
+
+    -- ファイル/ディレクトリの削除 (D)
+    -- workspace/willDeleteFiles で参照箇所の変更等を事前適用し、
+    -- 削除後に workspace/didDeleteFiles で LSP 内部状態を同期する
+    vim.keymap.set("n", "D", function()
+        local paths = fern_selected_paths()
+        if not paths or #paths == 0 then
+            return
+        end
+
+        local names = table.concat(
+            vim.tbl_map(function(p)
+                return vim.fn.fnamemodify(p, ":t")
+            end, paths),
+            ", "
+        )
+        vim.cmd("redraw")
+        local confirm = vim.fn.input("Delete " .. names .. "? [y/N]: ")
+        if confirm:lower() ~= "y" then
+            return
+        end
+
+        -- 削除前に LSP へ通知して workspace edit を適用する
+        M.will_delete_files(paths)
+
+        -- ファイルを削除する
+        local deleted = {}
+        for _, path in ipairs(paths) do
+            local flags = vim.fn.isdirectory(path) == 1 and "rf" or ""
+            if vim.fn.delete(path, flags) == 0 then
+                table.insert(deleted, path)
+            else
+                vim.notify("[fern-lsp] Failed to delete: " .. path, vim.log.levels.WARN)
+            end
+        end
+
+        if #deleted > 0 then
+            -- 削除後に LSP へ通知する
+            M.did_delete_files(deleted)
+        end
+
+        fern_reload()
+    end, { buffer = true, desc = "Fern: delete with LSP notification" })
+end
+
+return M

--- a/nvim/lua/xecua/fern_lsp.lua
+++ b/nvim/lua/xecua/fern_lsp.lua
@@ -1,5 +1,8 @@
 --- vim-fern と LSP の workspace file operation を統合するモジュール
---- fern の ftplugin から M.setup_keymaps() を呼び出して使う
+---
+--- 使い方:
+---   M.setup()         : VimEnter 等で一度だけ呼ぶ (fern-replacer BufWritePre/Post フック)
+---   M.setup_keymaps() : fern の ftplugin から呼ぶ (バッファローカルキーマップ設定)
 
 local M = {}
 
@@ -19,6 +22,10 @@ end
 local function apply_workspace_edit(edit, offset_encoding)
     vim.lsp.util.apply_workspace_edit(edit, offset_encoding or "utf-8")
 end
+
+-- ----------------------------------------------------------------
+-- 公開 API: 単一ファイル操作用
+-- ----------------------------------------------------------------
 
 --- workspace/willRenameFiles を送信し、返された workspace edit を適用する
 ---@param old_path string 変更前のファイルパス (絶対パス)
@@ -105,6 +112,79 @@ function M.did_delete_files(paths)
     end
 end
 
+-- ----------------------------------------------------------------
+-- fern-replacer フック (rename)
+-- ----------------------------------------------------------------
+
+--- BufWritePre と BufWritePost/BufUnload の間でリネームペアを受け渡すテーブル
+---@type table<integer, {old: string, new: string}[]>
+local pending_renames = {}
+
+--- fern-replacer バッファからリネームペアを計算して返す
+--- b:fern_replacer_candidates (旧パスの配列) とバッファ各行 (新ファイル名) を突き合わせる
+---@param bufnr integer
+---@return {old: string, new: string}[]
+local function compute_renames(bufnr)
+    local candidates = vim.b[bufnr].fern_replacer_candidates
+    if not candidates or #candidates == 0 then
+        return {}
+    end
+
+    local new_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+    local renames = {}
+
+    for i, old_path in ipairs(candidates) do
+        local new_line = new_lines[i]
+        if not new_line or new_line == "" then
+            break
+        end
+
+        -- 新ファイル名が絶対パスならそのまま、そうでなければ旧パスの親ディレクトリと結合する
+        local new_path = vim.startswith(new_line, "/") and new_line
+            or (vim.fn.fnamemodify(old_path, ":h") .. "/" .. new_line)
+
+        if old_path ~= new_path then
+            table.insert(renames, { old = old_path, new = new_path })
+        end
+    end
+
+    return renames
+end
+
+--- did_rename_files 通知とバッファ名の更新を行う (冪等)
+---@param bufnr integer
+local function flush_pending_renames(bufnr)
+    local renames = pending_renames[bufnr]
+    if not renames then
+        return
+    end
+    pending_renames[bufnr] = nil
+
+    -- 開いているバッファのパスを更新する
+    for _, r in ipairs(renames) do
+        for _, b in ipairs(vim.api.nvim_list_bufs()) do
+            if vim.api.nvim_buf_is_loaded(b) and vim.api.nvim_buf_get_name(b) == r.old then
+                vim.api.nvim_buf_set_name(b, r.new)
+                vim.api.nvim_buf_call(b, function()
+                    vim.cmd("edit")
+                end)
+            end
+        end
+    end
+
+    -- workspace/didRenameFiles を一括送信する
+    local files = vim.tbl_map(function(r)
+        return { oldUri = vim.uri_from_fname(r.old), newUri = vim.uri_from_fname(r.new) }
+    end, renames)
+    for _, client in ipairs(get_capable_clients("didRename")) do
+        client:notify("workspace/didRenameFiles", { files = files })
+    end
+end
+
+-- ----------------------------------------------------------------
+-- fern の ftplugin 用キーマップ
+-- ----------------------------------------------------------------
+
 --- fern の cursor node の絶対パスを返す
 ---@return string|nil
 local function fern_cursor_path()
@@ -113,7 +193,6 @@ local function fern_cursor_path()
 end
 
 --- fern で選択 (またはマーク) されているノードの絶対パスのリストを返す
---- マークされたノードがなければ cursor node のパスを返す
 ---@return string[]|nil
 local function fern_selected_paths()
     local ok, paths = pcall(
@@ -128,51 +207,78 @@ local function fern_reload()
     pcall(vim.fn["fern#action#call"], "reload:all")
 end
 
+-- ----------------------------------------------------------------
+-- 公開セットアップ関数
+-- ----------------------------------------------------------------
+
+--- fern-replacer バッファの保存前後に LSP rename 通知を行う autocmd を登録する
+--- vim-fern プラグインの lua_source (または lua_add) から一度だけ呼ぶこと
+function M.setup()
+    local augroup = vim.api.nvim_create_augroup("FernLspFileOps", { clear = true })
+
+    -- 保存前: workspace/willRenameFiles を一括送信して workspace edit を適用する
+    vim.api.nvim_create_autocmd("BufWritePre", {
+        group = augroup,
+        callback = function(args)
+            local bufnr = args.buf
+            if vim.bo[bufnr].filetype ~= "fern-replacer" then
+                return
+            end
+
+            local renames = compute_renames(bufnr)
+            if #renames == 0 then
+                return
+            end
+
+            local files = vim.tbl_map(function(r)
+                return { oldUri = vim.uri_from_fname(r.old), newUri = vim.uri_from_fname(r.new) }
+            end, renames)
+
+            for _, client in ipairs(get_capable_clients("willRename")) do
+                local result = client:request_sync("workspace/willRenameFiles", { files = files }, 1500)
+                if result and not result.err and result.result then
+                    apply_workspace_edit(result.result, client.offset_encoding)
+                end
+            end
+
+            -- BufWritePost/BufUnload で参照できるよう保存する
+            pending_renames[bufnr] = renames
+        end,
+    })
+
+    -- 保存後: workspace/didRenameFiles を送信する
+    -- BufWriteCmd 経由の場合も BufWritePost が発火するケースに対応する
+    vim.api.nvim_create_autocmd("BufWritePost", {
+        group = augroup,
+        callback = function(args)
+            if vim.bo[args.buf].filetype ~= "fern-replacer" then
+                return
+            end
+            flush_pending_renames(args.buf)
+        end,
+    })
+
+    -- fern が rename 後にバッファを閉じる場合の BufWritePost 非発火への対策
+    vim.api.nvim_create_autocmd("BufUnload", {
+        group = augroup,
+        callback = function(args)
+            if vim.bo[args.buf].filetype ~= "fern-replacer" then
+                return
+            end
+            flush_pending_renames(args.buf)
+        end,
+    })
+end
+
 --- vim-fern バッファ用の LSP file operation キーマップを設定する
 --- fern の ftplugin から呼び出すこと
 function M.setup_keymaps()
     -- ファイル/ディレクトリのリネーム (r)
-    -- workspace/willRenameFiles でインポートパス等を事前更新し、
-    -- リネーム後に workspace/didRenameFiles で LSP 内部状態を同期する
-    vim.keymap.set("n", "r", function()
-        local old_path = fern_cursor_path()
-        if not old_path then
-            return
-        end
-
-        local old_name = vim.fn.fnamemodify(old_path, ":t")
-        vim.cmd("redraw")
-        local new_name = vim.fn.input("New name: ", old_name)
-        if new_name == "" or new_name == old_name then
-            return
-        end
-
-        local new_path = vim.fn.fnamemodify(old_path, ":h") .. "/" .. new_name
-
-        -- リネーム前に LSP へ通知して workspace edit (インポートパス変更等) を適用する
-        M.will_rename_files(old_path, new_path)
-
-        -- 実際にリネームする
-        if vim.fn.rename(old_path, new_path) ~= 0 then
-            vim.notify("[fern-lsp] Rename failed: " .. old_path, vim.log.levels.ERROR)
-            return
-        end
-
-        -- 対応するバッファが開いていればパスを更新する
-        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
-            if vim.api.nvim_buf_is_loaded(bufnr) and vim.api.nvim_buf_get_name(bufnr) == old_path then
-                vim.api.nvim_buf_set_name(bufnr, new_path)
-                vim.api.nvim_buf_call(bufnr, function()
-                    vim.cmd("edit")
-                end)
-            end
-        end
-
-        -- リネーム後に LSP へ通知する
-        M.did_rename_files(old_path, new_path)
-
-        fern_reload()
-    end, { buffer = true, desc = "Fern: rename with LSP notification" })
+    -- fern ネイティブの rename action を使い、fern-replacer バッファ経由で LSP に通知する
+    vim.keymap.set("n", "r", "<Plug>(fern-action-rename)", {
+        buffer = true,
+        desc = "Fern: rename (LSP 通知付き)",
+    })
 
     -- 新規ファイル作成 (n)
     vim.keymap.set("n", "n", function()
@@ -233,8 +339,6 @@ function M.setup_keymaps()
     end, { buffer = true, desc = "Fern: new directory with LSP notification" })
 
     -- ファイル/ディレクトリの削除 (D)
-    -- workspace/willDeleteFiles で参照箇所の変更等を事前適用し、
-    -- 削除後に workspace/didDeleteFiles で LSP 内部状態を同期する
     vim.keymap.set("n", "D", function()
         local paths = fern_selected_paths()
         if not paths or #paths == 0 then
@@ -253,10 +357,8 @@ function M.setup_keymaps()
             return
         end
 
-        -- 削除前に LSP へ通知して workspace edit を適用する
         M.will_delete_files(paths)
 
-        -- ファイルを削除する
         local deleted = {}
         for _, path in ipairs(paths) do
             local flags = vim.fn.isdirectory(path) == 1 and "rf" or ""
@@ -268,7 +370,6 @@ function M.setup_keymaps()
         end
 
         if #deleted > 0 then
-            -- 削除後に LSP へ通知する
             M.did_delete_files(deleted)
         end
 

--- a/nvim/lua/xecua/lsp.lua
+++ b/nvim/lua/xecua/lsp.lua
@@ -1,4 +1,19 @@
--- vim.lsp.config('*', {})
+-- workspace file operation capabilities を全 LSP サーバに宣言する
+-- LSP サーバ側が willRenameFiles 等を登録するために必要
+vim.lsp.config("*", {
+    capabilities = vim.tbl_deep_extend("force", vim.lsp.protocol.make_client_capabilities(), {
+        workspace = {
+            fileOperations = {
+                didCreate = true,
+                willCreate = true,
+                didRename = true,
+                willRename = true,
+                didDelete = true,
+                willDelete = true,
+            },
+        },
+    }),
+})
 
 vim.lsp.enable({
     "denols",


### PR DESCRIPTION
fern でのリネーム/ファイル作成/ディレクトリ作成/削除に合わせて
workspace/will*Files および workspace/did*Files を LSP サーバへ送信し、
返された WorkspaceEdit (インポートパス変更等) をバッファへ反映する。

- nvim/lua/xecua/fern_lsp.lua を新規作成
  - will/did rename・create・delete の各 LSP 通知関数
  - setup_keymaps(): fern ftplugin から呼ぶバッファローカルキーマップ設定
    - r  : リネーム (will → rename → バッファ名更新 → did)
    - n  : 新規ファイル (will → writefile → did)
    - N  : 新規ディレクトリ (will → mkdir → did)
    - D  : 削除 (will → delete → did)
- nvim/dpp/plugins.toml
  - igorlfs/nvim-lsp-file-operations の lua_post_source に
    vim.lsp.config("*", ...) を追加し、vim.lsp.enable() 経由の
    サーバにも file operation capabilities を通知するよう修正
  - fern ftplugin の末尾に setup_keymaps() 呼び出しを追加

https://claude.ai/code/session_01Nki9sigCcADUFEGc84JqWd